### PR TITLE
[Hotfix] Fix ops example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_policy(SET CMP0048 NEW)
 project(S2E_AOBC_EXAMPLE
   LANGUAGES CXX
   DESCRIPTION "S2E_AOBC_EXAMPLE"
-  VERSION 0.0.0
+  VERSION 1.0.1
   )
 
 cmake_minimum_required(VERSION 3.13)

--- a/data/initialize_files/components/wings_command_sender_to_c2a/example.ops
+++ b/data/initialize_files/components/wings_command_sender_to_c2a/example.ops
@@ -1,12 +1,12 @@
 .# ===== SILS Test =====
 .#
 .# 
-.AOBC_RT.Cmd_APP_AOCS_MANAGER_SET_MASS 12.6
+.AOBC_RT.APP_AOCS_MANAGER_SET_MASS 12.6
  wait_sec 15
- AOBC_RT.Cmd_MM_START_TRANSITION 2
+ AOBC_RT.MM_START_TRANSITION 2
  wait_sec 3
  check_value AOBC_ANOMALY.TEMPERATURE.THRESHOLD.PIC_UPPER_DEGC == 90  # check_valueは今は使えない
  check_value AOBC_ANOMALY.TEMPERATURE.THRESHOLD.PIC_LOWER_DEGC == -40 # check_valueは今は使えない
  let mode_id = 2 # letはいまはつかえない
- AOBC_RT.Cmd_MM_START_TRANSITION {mode_id} # letを前提とした{}付きの引数があるとコマンドは送信されない
+ AOBC_RT.MM_START_TRANSITION {mode_id} # letを前提とした{}付きの引数があるとコマンドは送信されない
 .# 変更反映を確認


### PR DESCRIPTION
## Related issues
NA

## Description
I removed the `Cmd_` prefix in the `example.ops` file.

## Test results
NA

## Impact
NA

## Supplementary information
NA
